### PR TITLE
Comments added for DEBUG SOCIAL LOGIN ERROR URL

### DIFF
--- a/demo/demo_unifi_portal/settings.py
+++ b/demo/demo_unifi_portal/settings.py
@@ -23,7 +23,8 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = '+%q=^7@2k2ipohgguyw@08=2#f#^my&$(3l7+2^l(42nuq-95+'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+# When debug is False /static will no logner be served by Django. You will need to serve it with Apahce/Nginx
+DEBUG = False
 
 ALLOWED_HOSTS = ['*']
 
@@ -153,4 +154,5 @@ except ImportError:
 
 AUTHENTICATION_BACKENDS = UNIFI_AUTHENTICATION_BACKENDS
 SOCIAL_AUTH_PIPELINE = UNIFI_SOCIAL_AUTH_PIPELINE
+#When DEBUG = True Social Auth exception handling to redirected url is disabled
 SOCIAL_AUTH_LOGIN_ERROR_URL = '/guest/s/default/'

--- a/django_unifi_portal/forms.py
+++ b/django_unifi_portal/forms.py
@@ -67,7 +67,7 @@ class UnifiRegistrationForm(ModelForm):
     buttons = Template("""
         <button class="waves-effect waves-light btn" type="submit">Submit</button>
     """)
-
+#Sign in button to allow user to navigate back to Login form from registration form 
      buttons = Template("""
         <a href="{% url 'unifi_login' %}" class="waves-effect waves-teal btn-flat">Sign in</a>
         <button class="waves-effect waves-light btn" type="submit">Login</button>

--- a/django_unifi_portal/forms.py
+++ b/django_unifi_portal/forms.py
@@ -68,6 +68,12 @@ class UnifiRegistrationForm(ModelForm):
         <button class="waves-effect waves-light btn" type="submit">Submit</button>
     """)
 
+     buttons = Template("""
+        <a href="{% url 'unifi_login' %}" class="waves-effect waves-teal btn-flat">Sign in</a>
+        <button class="waves-effect waves-light btn" type="submit">Login</button>
+    """)
+
+
     title = "Registration"
 
     class Meta:


### PR DESCRIPTION
Debug set to False
Added comments to inform that DEBUG need to be set to False when using Exception handling for Socail Auth to redirect back to login. 

Also by setting DEBUG = False Django server no longers serves /static - Required Apache/Nginx proxying Django and serving /static